### PR TITLE
PRAX-216 Set time as part of the default value for cooldatetimepicker

### DIFF
--- a/src/components/CoolDateTimeRangePicker.js
+++ b/src/components/CoolDateTimeRangePicker.js
@@ -55,7 +55,7 @@ const CoolDateTimeRangePicker = ({
   // ensure the from value is always after minimum and to value is always after from value
   useEffect(() => {
     if (defaultValue && lastDefaultValue !== defaultValue) {
-      setValue([moment(defaultValue).startOf('day'), fromTime, toDate, toTime]);
+      setValue([moment(defaultValue).startOf('day'), moment(defaultValue).startOf('minute'), toDate, moment(defaultValue).startOf('minute')]);
       setLastDefaultValue(defaultValue);
     } else if (fromDate?.isBefore(minimum, 'd')) {
       setValue([null, fromTime, toDate, toTime]);


### PR DESCRIPTION
<!--
    Title format:
    PRAX-000 Title
-->

## Pull request checklist

- [x] Documentation: My code is documented where necessary.
- [x] Test: I have successfully tested the functionality locally.
- [x] Lint: `npm run lint` has passed locally and any fixes were made for failures.
