### PR TITLE
Bugfix [reviewId].js

### DIFF
--- a/src/pages/reviews/[reviewId].js
+++ b/src/pages/reviews/[reviewId].js
@@ -122,6 +122,7 @@ const ShowReviewPage = () => {
       </AppPage>
     );
   }
+  // Page is not shown when the review has not been submitted
   if (submitted === false) {
     return (
       <AppPage title="Show Review">
@@ -133,6 +134,7 @@ const ShowReviewPage = () => {
       </AppPage>
     );
   }
+  // Show an empty page for the time it takes to load the value of "submitted"
   return (
     <AppPage title="Show Review">
       <IonCenterContent>


### PR DESCRIPTION
# PRAX-291

Habe die Reihenfolge der if-Statements umgekehrt, die beiden konkreten Fälle als ===true und ===false auscodiert sowie einen "default case" mit einer leeren Seite hinzugefügt, der für den Bruchteil einer Sekunde angezeigt wird, bevor der boolean aus der Datenbank ausgelesen wurde und die Seite in eine der beiden if-Statements springt

<!--
    Title format:
    PRAX-000 Title
-->

## Pull request checklist

- [x] Documentation: My code is documented where necessary.
- [x] Test: I have successfully tested the functionality locally.
- [x] Lint: `npm run lint` has passed locally and any fixes were made for failures.
